### PR TITLE
fix when initialized here [-Werror=reorder]

### DIFF
--- a/include/st_tree_detail.h
+++ b/include/st_tree_detail.h
@@ -109,8 +109,8 @@ struct max_maintainer {
 
     protected:
     typedef typename Alloc::template rebind<Unsigned>::other unsigned_allocator;
-    Unsigned _max;
     vector<Unsigned, unsigned_allocator> _hist;
+    Unsigned _max;
 };
 
 

--- a/include/st_tree_nodes.h
+++ b/include/st_tree_nodes.h
@@ -177,10 +177,10 @@ struct node_base {
     protected:
     tree_type* _tree;
     size_type _size;
-    max_maintainer<size_type, allocator_type> _depth;
     node_type* _parent;
     data_type _data;
     cs_type _children;
+    max_maintainer<size_type, allocator_type> _depth;
 
     bool _default_constructed() const {
         return (NULL == _parent) && (NULL == _tree);


### PR DESCRIPTION
when compiler in GCC7，
st_tree/include/st_tree_detail.h:113:42: error: 'st_tree::detail::max_maintainer<long unsigned int, std::allocator<const char*> >::_hist' will be initialized after [-Werror=reorder]
     vector<Unsigned, unsigned_allocator> _hist;
                                          ^~~~~
st_tree/include/st_tree_detail.h:112:14: error:   'long unsigned int st_tree::detail::max_maintainer<long unsigned int, std::allocator<const char*> >::_max' [-Werror=reorder]
     Unsigned _max;
              ^~~~
util/container/st_tree/include/st_tree_detail.h:58:5: error:   when initialized here [-Werror=reorder]

ajust order 