### PR TITLE
Adding cmake installation instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 2.6)
-project(st_tree)
+cmake_minimum_required(VERSION 3.0)
+project(st_tree VERSION 1.0.6)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # Build against ANSI c++ standards
 IF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC OR MINGW)
@@ -14,3 +17,41 @@ add_subdirectory(examples)
 
 # testing programs
 add_subdirectory(tests)
+
+set(ST_TREE_HEADERS
+    include/st_tree_detail.h
+    include/st_tree.h
+    include/st_tree_iterators.h
+    include/st_tree_nodes.h)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets)
+
+# Makes the project importable from the build directory
+export(EXPORT ${PROJECT_NAME}-targets
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+
+install(FILES ${ST_TREE_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${${PROJECT_NAME}_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+install(EXPORT ${PROJECT_NAME}-targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)

--- a/cmake/st_treeConfig.cmake.in
+++ b/cmake/st_treeConfig.cmake.in
@@ -1,0 +1,15 @@
+# st_tree cmake module
+# This module sets the following variables in your project:
+#
+#   st_tree_FOUND        - true if st_tree found on the system
+#   st_tree_INCLUDE_DIRS - the directory containing st_tree headers
+#   st_tree_LIBRARY      - not set, unneeded for header-only library
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET @PROJECT_NAME@)
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+  get_target_property(@PROJECT_NAME@_INCLUDE_DIRS st_tree INTERFACE_INCLUDE_DIRECTORIES)
+endif()


### PR DESCRIPTION
This PR adds installation instructions for cmake. With this PR, users can use
```
make install
```
to install the headers. Afterwards they can use the library in downstream projects with modern cmake syntax like:
```
find_package(st_tree REQUIRED)
[...]
target_link_libraries(<target> st_tree)
```
With modern cmake, linking this interface library passes transitively all cmake properties (like include paths and build flags) from st_tree to the downstream target.