### PR TITLE
Added emplace functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CMakePackageConfigHelpers)
 
 # Build against ANSI c++ standards
 IF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC OR MINGW)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi -pedantic")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi -pedantic -std=c++11")
 ENDIF()
 
 # include

--- a/include/st_tree.h
+++ b/include/st_tree.h
@@ -186,13 +186,16 @@ struct tree {
         return *_root;
     }
 
-    void insert(const data_type& data) {
+    template< class... Args >
+    void emplace( Args&&... args ){
         clear();
         _root = _new_node();
-        _root->_data = data;
+        _root->_data = data_type(std::forward<Args>(args) ... );
         _root->_tree = this;
         _root->_depth.insert(1);
     }
+
+    void insert(const data_type& data) { emplace(data); };
 
     // there is only one node to erase from the tree: the root
     void erase() { clear(); }

--- a/include/st_tree_nodes.h
+++ b/include/st_tree_nodes.h
@@ -408,14 +408,17 @@ struct node_raw: public node_base<Tree, node_raw<Tree, Data>, vector<node_raw<Tr
     void erase(const iterator& j) { this->_erase(j); }
     void erase(const iterator& F, const iterator& L) { this->_erase(F, L); }
 
-    iterator insert(const data_type& data) {
+    template<class... Args>
+    iterator emplace_insert(Args&&... args){
         node_type* n = this->tree()._new_node();
-        n->_data = data;
+        n->_data = data_type(std::forward<Args>(args) ... );
         n->_depth.insert(1);
         this->_children.push_back(n);
         this->_graft(n);
         return iterator(this->_children.begin()+(this->_children.size()-1));
     }
+
+    iterator insert(const data_type& data) { return emplace_insert(data); }
 
     iterator insert(const node_type& src) {
         node_type* n = src._copy_data(this->tree());
@@ -429,6 +432,8 @@ struct node_raw: public node_base<Tree, node_raw<Tree, Data>, vector<node_raw<Tr
         return insert(src.root());
     }
 
+    template< class... Args >
+    void emplace_back(Args&&... args){ emplace_insert(std::forward<Args>(args) ... ); }
     void push_back(const data_type& data) { insert(data); }
     void push_back(const node_type& src) { insert(src); }
     void push_back(const tree_type& src) { insert(src); }
@@ -679,15 +684,18 @@ struct node_ordered: public node_base<Tree, node_ordered<Tree, Data, Compare>, m
         return c;
     }
 
-    iterator insert(const data_type& data) {
+    template<class... Args>
+    iterator emplace_insert(Args&&... args){
         node_type* n = this->tree()._new_node();
-        n->_data = data;
+        n->_data = data_type(std::forward<Args>(args) ... );
         iterator r(this->_children.insert(n));
         // insertions always happen for multiset, hence no checking
         n->_depth.insert(1);
         this->_graft(n);
         return r;
     }
+
+    iterator insert(const data_type& data) { return emplace_insert(data); }
 
     iterator insert(const node_type& src) {
         node_type* n = src._copy_data(this->tree());
@@ -874,7 +882,8 @@ struct node_keyed: public node_base<Tree, node_keyed<Tree, Data, Key, Compare>, 
         return c;
     }
 
-    pair<iterator, bool> insert(const key_type& key, const data_type& data) {
+    template<class... Args>
+    pair<iterator, bool> emplace_insert(const key_type& key, Args&&... args){
         node_type* n = this->tree()._new_node();
         n->_key = key;
         pair<cs_iterator, bool> r = this->_children.insert(cs_value_type(&(n->_key), n));
@@ -885,11 +894,13 @@ struct node_keyed: public node_base<Tree, node_keyed<Tree, Data, Key, Compare>, 
             return rr;
         }
         // do this work if we know we actually inserted 
-        n->_data = data;
+        n->_data = data_type(std::forward<Args>(args) ... );
         n->_depth.insert(1);
         this->_graft(n);
         return rr;
     }
+
+    pair<iterator, bool> insert(const key_type& key, const data_type& data) { return emplace_insert(key, data); }
 
     pair<iterator, bool> insert(const kv_pair& kv) { return insert(kv.first, kv.second); }
 

--- a/tests/ut_keyed.cpp
+++ b/tests/ut_keyed.cpp
@@ -54,6 +54,48 @@ BOOST_AUTO_TEST_CASE(insert_subnodes) {
     BOOST_CHECK_EQUAL(t1.root()["1"].data(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(emplace_subnodes) {
+    struct str1 {
+        int i1;
+        std::string s1;
+        str1() {
+            i1 = 0;
+            s1 = "";
+        }
+        str1(int i, const std::string s) {
+            i1 = i;
+            s1 = s;
+        }
+    };
+
+    tree<str1, keyed<std::string> > t1;
+
+    t1.emplace(7 , "7");
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.size(), 1);
+    BOOST_CHECK_EQUAL(t1.depth(), 1);
+    BOOST_CHECK_EQUAL(t1.root().size(), 0);
+
+    t1.root().emplace_insert("0", 8, "8");
+    BOOST_CHECK_EQUAL(t1.size(), 2);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 1);
+
+    t1.root().emplace_insert("1", 9, "9");
+    BOOST_CHECK_EQUAL(t1.size(), 3);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 2);
+
+    BOOST_CHECK_EQUAL(t1.root().data().i1, 7);
+    BOOST_CHECK_EQUAL(t1.root()["0"].data().i1, 8);
+    BOOST_CHECK_EQUAL(t1.root()["1"].data().i1, 9);
+
+    BOOST_CHECK_EQUAL(t1.root().data().s1, "7");
+    BOOST_CHECK_EQUAL(t1.root()["0"].data().s1, "8");
+    BOOST_CHECK_EQUAL(t1.root()["1"].data().s1, "9");
+}
 
 BOOST_AUTO_TEST_CASE(clear) {
     tree<int, keyed<std::string> > t1;

--- a/tests/ut_ordered.cpp
+++ b/tests/ut_ordered.cpp
@@ -54,6 +54,48 @@ BOOST_AUTO_TEST_CASE(insert_subnodes) {
     CHECK_TREE(t1, subtree_size(), "3 1 1");
 }
 
+BOOST_AUTO_TEST_CASE(emplace_subnodes){
+    struct str1 {
+        int i1;
+        std::string s1;
+        str1() {
+            i1 = 0;
+            s1 = "";
+        }
+        str1(int i, const std::string s) {
+            i1 = i;
+            s1 = s;
+        }
+        bool operator<(const str1& b) const {
+            return i1 < b.i1;
+        }
+    };
+
+    tree<str1, ordered<>> t1;
+
+    t1.emplace(7, "7");
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.size(), 1);
+    BOOST_CHECK_EQUAL(t1.depth(), 1);
+    BOOST_CHECK_EQUAL(t1.root().size(), 0);
+
+    t1.root().emplace_insert(9, "9");
+    BOOST_CHECK_EQUAL(t1.size(), 2);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 1);
+
+    t1.root().emplace_insert(8, "8");
+    BOOST_CHECK_EQUAL(t1.size(), 3);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 2);
+
+    CHECK_TREE(t1, ply(), "0 1 1");
+    CHECK_TREE(t1, depth(), "2 1 1");
+    CHECK_TREE(t1, subtree_size(), "3 1 1");
+}
+
 
 BOOST_AUTO_TEST_CASE(clear) {
     tree<int, ordered<> > t1;

--- a/tests/ut_raw.cpp
+++ b/tests/ut_raw.cpp
@@ -55,6 +55,48 @@ BOOST_AUTO_TEST_CASE(insert_subnodes) {
     BOOST_CHECK_EQUAL(t1.root()[1].data(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(emplace_subnodes) {
+    struct str1 {
+        int i1;
+        std::string s1;
+        str1() {
+            i1 = 0;
+            s1 = "";
+        }
+        str1(int i, const std::string s) {
+            i1 = i;
+            s1 = s;
+        }
+    };
+
+    tree<str1> t1;
+
+    t1.emplace(7, "7");
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.size(), 1);
+    BOOST_CHECK_EQUAL(t1.depth(), 1);
+    BOOST_CHECK_EQUAL(t1.root().size(), 0);
+
+    t1.root().emplace_back(8, "8");
+    BOOST_CHECK_EQUAL(t1.size(), 2);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 1);
+
+    t1.root().emplace_insert(9, "9");
+    BOOST_CHECK_EQUAL(t1.size(), 3);
+    BOOST_CHECK_EQUAL(t1.depth(), 2);
+    BOOST_CHECK_EQUAL(t1.empty(), false);
+    BOOST_CHECK_EQUAL(t1.root().size(), 2);
+
+    BOOST_CHECK_EQUAL(t1.root().data().i1, 7);
+    BOOST_CHECK_EQUAL(t1.root()[0].data().i1, 8);
+    BOOST_CHECK_EQUAL(t1.root()[1].data().i1, 9);
+    BOOST_CHECK_EQUAL(t1.root().data().s1, "7");
+    BOOST_CHECK_EQUAL(t1.root()[0].data().s1, "8");
+    BOOST_CHECK_EQUAL(t1.root()[1].data().s1, "9");
+}
+
 
 BOOST_AUTO_TEST_CASE(clear) {
     tree<int> t1;


### PR DESCRIPTION
This PR adds emplacement operators to construct leaves / nodes. There is a new `emplace()` that mimics `insert()` but constructs the object in-place, and `emplace_back()` that mimics `push_back()` but in-place.

Please note that C++11 is required for the emplace methods due to the use of variadic templates. I hope this is not of concern?