### PR TITLE
Fixed std::allocator usage for C++17 and C++20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ x05_node_methods
 x06_graft
 x07_iterators
 unit_tests
+.DS_Store

--- a/include/st_tree.h
+++ b/include/st_tree.h
@@ -122,8 +122,8 @@ struct tree {
 
     public:
     typedef typename nt_dispatch::node_type node_type;
-    typedef typename Alloc::template rebind<node_type>::other node_allocator_type;
-    typedef typename Alloc::template rebind<typename nt_dispatch::cs_value_type>::other cs_allocator_type;
+    typedef typename std::allocator<node_type> node_allocator_type;
+    typedef typename std::allocator<typename nt_dispatch::cs_value_type> cs_allocator_type;
 
     protected:
     typedef typename node_type::base_type node_base_type;
@@ -287,13 +287,13 @@ struct tree {
 
     node_type* _new_node() {
         node_type* n = _node_allocator.allocate(1);
-        _node_allocator.construct(n, _node_init_val);
+        std::allocator_traits<node_allocator_type>::construct(_node_allocator, n, _node_init_val);
         return n;
     }
 
     void _delete_node(node_type* n) {
-        _node_allocator.destroy(n);
-        _node_allocator.deallocate(n, 1);
+        std::allocator_traits<node_allocator_type>::destroy(_node_allocator, n);
+        std::allocator_traits<node_allocator_type>::deallocate(_node_allocator, n, 1);
     }
 
     void _prune(node_type* n) {

--- a/include/st_tree_detail.h
+++ b/include/st_tree_detail.h
@@ -108,7 +108,7 @@ struct max_maintainer {
     }
 
     protected:
-    typedef typename Alloc::template rebind<Unsigned>::other unsigned_allocator;
+    typedef typename std::allocator<Unsigned> unsigned_allocator;
     vector<Unsigned, unsigned_allocator> _hist;
     Unsigned _max;
 };

--- a/include/st_tree_iterators.h
+++ b/include/st_tree_iterators.h
@@ -80,7 +80,7 @@ struct b1st_iterator {
     bool operator!=(const b1st_iterator& rhs) const { return _queue != rhs._queue; }
 
     protected:
-    typedef typename Alloc::template rebind<node_type*>::other node_ptr_allocator_type;
+    typedef typename std::allocator<node_type*> node_ptr_allocator_type;
     deque<node_type*, node_ptr_allocator_type> _queue;
 };
 
@@ -183,7 +183,7 @@ struct d1st_post_iterator {
     bool operator!=(const d1st_post_iterator& rhs) const { return _stack != rhs._stack; }
 
     protected:
-    typedef typename Alloc::template rebind<frame>::other frame_allocator_type;
+    typedef typename std::allocator<frame> frame_allocator_type;
     vector<frame, frame_allocator_type> _stack;
 };
 
@@ -276,7 +276,7 @@ struct d1st_pre_iterator {
     bool operator!=(const d1st_pre_iterator& rhs) const { return _stack != rhs._stack; }
 
     protected:
-    typedef typename Alloc::template rebind<frame>::other frame_allocator_type;
+    typedef typename std::allocator<frame> frame_allocator_type;
     vector<frame, frame_allocator_type> _stack;
 };
 


### PR DESCRIPTION
Fix to build once again in C++20

rebind was deprecated in C++17 and removed in C++20
construct, destroy, and deallocate were deprecated and removed likewise and now the proper solution is to use std::allocator_traits

I also added .DS_store to the .gitignore as it is generated on my Mac